### PR TITLE
#20 - Conflict with Base.contains in Julia v1.5

### DIFF
--- a/src/init_LazySets.jl
+++ b/src/init_LazySets.jl
@@ -1,6 +1,10 @@
 export SetAtom, contains, is_contained_in, is_disjoint_from, intersects
 import .LazySets: dim, project
 
+if VERSION >= v"1.5"
+    import Base: contains
+end
+
 using .LazySets: LazySet, ⊆, isdisjoint
 
 """

--- a/src/init_LazySets.jl
+++ b/src/init_LazySets.jl
@@ -1,7 +1,7 @@
 export SetAtom, contains, is_contained_in, is_disjoint_from, intersects
 import .LazySets: dim, project
 
-if VERSION >= v"1.5"
+@static if VERSION >= v"1.5"
     import Base: contains
 end
 


### PR DESCRIPTION
Closes #20.

I tested locally with the nightly Julia build, which is a v1.6 instance.