### PR TITLE
#46 - Fix piracy with `contains`

### DIFF
--- a/src/init_LazySets.jl
+++ b/src/init_LazySets.jl
@@ -1,9 +1,5 @@
-export SetAtom, contains, is_contained_in, is_disjoint_from, intersects
+export SetAtom, is_contained_in, is_disjoint_from, intersects
 import .LazySets: dim, project
-
-@static if VERSION >= v"1.5"
-    import Base: contains
-end
 
 using .LazySets: LazySet, ⊆, isdisjoint
 
@@ -64,7 +60,7 @@ function project(sa::SetAtom, vars::AbstractVector{Int})
 end
 
 # fallback
-function project(p::Predicate, vars::AbstractVector{Int})
+function project(p::Predicate, ::AbstractVector{Int})
     throw(ArgumentError("`project` cannot be applied to a `$(typeof(p))`; " *
                         "use a `SetAtom` instead"))
 end
@@ -89,13 +85,9 @@ function project(d::Disjunction, vars::AbstractVector{Int})
     return Disjunction(disjuncts)
 end
 
-# ==========================================
-# Convenience functions to create predicates
-# ==========================================
-
-function contains(X::LazySet)
-    return SetAtom(X, ⊆)
-end
+# =====================================================
+# Convenience functions to create common set predicates
+# =====================================================
 
 function is_contained_in(X::LazySet)
     return SetAtom(X, (X, Y) -> Y ⊆ X)

--- a/test/Aqua.jl
+++ b/test/Aqua.jl
@@ -2,7 +2,5 @@ using MathematicalPredicates, Test
 import Aqua
 
 @testset "Aqua tests" begin
-    Aqua.test_all(MathematicalPredicates;
-                  # `contains` is a known piracy
-                  piracies=(treat_as_own=Function[contains],))
+    Aqua.test_all(MathematicalPredicates)
 end

--- a/test/LazySets.jl
+++ b/test/LazySets.jl
@@ -10,7 +10,7 @@ B2_proj = project(B2, [1])
 P1 = is_contained_in(B1)
 @test P1(S) && P1(B1) && !P1(B2)
 
-P2 = contains(S)
+P2 = SetAtom(S, ⊆)
 @test P2(S) && P2(B1) && !P2(B2)
 
 # dim is only available for SetAtom types


### PR DESCRIPTION
Closes #46.

After thinking about it for a while, I suggest to simply remove the function. It is not a common use case and also very easy to define manually.